### PR TITLE
fix: handle nested progress and backend noise

### DIFF
--- a/stqdm/stqdm.py
+++ b/stqdm/stqdm.py
@@ -1,3 +1,4 @@
+import io
 import re
 from contextlib import contextmanager
 from typing import TYPE_CHECKING, Any, Iterable, Iterator, Optional, cast
@@ -46,6 +47,9 @@ class stqdm(tqdm):  # pylint: disable=invalid-name,inconsistent-mro
         self.st_container: "DeltaGenerator" = kwargs.pop("st_container", st.container())
         self._backend: bool = kwargs.pop("backend", False)
         self._frontend: bool = kwargs.pop("frontend", True)
+        if not self._backend:
+            # Route tqdm's terminal writes to an in-memory sink so close() cannot leak a trailing newline.
+            kwargs["file"] = io.StringIO()
 
         # Will be set when necessary
         self._st_progress_bar: Optional["DeltaGenerator"] = None
@@ -163,13 +167,14 @@ class stqdm(tqdm):  # pylint: disable=invalid-name,inconsistent-mro
 
         if can_display_progress_bar and self.should_display_progress_bar:
             total = cast(float, total)  # total is not None
+            progress = min(max(n / total, 0.0), 1.0)
             if not can_display_text:
-                self.st_progress_bar.progress(n / total)
+                self.st_progress_bar.progress(progress)
             elif IS_TEXT_INSIDE_PROGRESS_AVAILABLE:
-                self.st_progress_bar.progress(n / total, text=meter_text)
+                self.st_progress_bar.progress(progress, text=meter_text)
             else:
                 self.st_text.write(meter_text)
-                self.st_progress_bar.progress(n / total)
+                self.st_progress_bar.progress(progress)
         else:
             if can_display_text:
                 self.st_text.write(meter_text)

--- a/tests/test_streamlit_apps.py
+++ b/tests/test_streamlit_apps.py
@@ -35,36 +35,38 @@ def freeze_time_and_mock_long_running_task(original_date: str):
             yield frozen_datetime
 
 
-def issue_101_nested_loops_issue() -> None:
-    """Reproduce the nested loop progress update pattern from issue 101."""
-    from functools import partial  # pylint: disable=import-outside-toplevel
+ISSUE_101_NESTED_LOOPS_SCRIPT = """
+from functools import partial
 
-    import streamlit as st  # pylint: disable=import-outside-toplevel
+import streamlit as st
+from stqdm import stqdm
 
-    from stqdm import stqdm  # pylint: disable=import-outside-toplevel
-
-    progress = partial(stqdm, st_container=st.sidebar)
-
-    def subfun(total: int) -> None:
-        for _ in progress(range(total), desc="paragraph"):
-            pass
-
-    sections = "ABCDEFGHIJK"
-    with progress(total=len(sections), desc="Working on") as pbar:
-        for section_counter, draft_section in enumerate(sections):
-            pbar.update(section_counter)
-            pbar.set_description(desc=f"Section '{draft_section}'")
-            subfun(3)
+progress = partial(stqdm, st_container=st.sidebar)
 
 
-def issue_98_two_stqdm_instances() -> None:
-    """Reproduce the consecutive rerun pattern from issue 98."""
-    from stqdm import stqdm  # pylint: disable=import-outside-toplevel
-
-    for _ in stqdm(range(2)):
+def subfun(total: int) -> None:
+    for _ in progress(range(total), desc="paragraph"):
         pass
-    for _ in stqdm(range(2)):
-        pass
+
+
+sections = "ABCDEFGHIJK"
+with progress(total=len(sections), desc="Working on") as pbar:
+    for section_counter, draft_section in enumerate(sections):
+        pbar.update(section_counter)
+        pbar.set_description(desc=f"Section '{draft_section}'")
+        subfun(3)
+"""
+
+
+ISSUE_98_TWO_STQDM_INSTANCES_SCRIPT = """
+from stqdm import stqdm
+
+for _ in stqdm(range(2)):
+    pass
+
+for _ in stqdm(range(2)):
+    pass
+"""
 
 
 @pytest.mark.parametrize("stop_iterations,total_iterations,task_duration", [(10, 50, 5), (13, 25, 3), (0, 50, 5), (50, 50, 2)])
@@ -154,7 +156,7 @@ def test_scoped_configuration_demo_renders_description():
 
 def test_issue_101_nested_loops_do_not_raise_streamlit_api_exception():
     with freeze_time_and_mock_long_running_task("2024-01-01"):
-        app_test = AppTest.from_function(issue_101_nested_loops_issue)
+        app_test = AppTest.from_string(ISSUE_101_NESTED_LOOPS_SCRIPT)
         app_test.run(timeout=5)
 
     assert not app_test.exception
@@ -166,7 +168,7 @@ def test_issue_101_nested_loops_do_not_raise_streamlit_api_exception():
 
 def test_issue_98_two_stqdm_instances_survive_reruns():
     with freeze_time_and_mock_long_running_task("2024-01-01"):
-        app_test = AppTest.from_function(issue_98_two_stqdm_instances)
+        app_test = AppTest.from_string(ISSUE_98_TWO_STQDM_INSTANCES_SCRIPT)
         app_test.run(timeout=5)
         app_test.run(timeout=5)
 

--- a/tests/test_streamlit_apps.py
+++ b/tests/test_streamlit_apps.py
@@ -35,6 +35,38 @@ def freeze_time_and_mock_long_running_task(original_date: str):
             yield frozen_datetime
 
 
+def issue_101_nested_loops_issue() -> None:
+    """Reproduce the nested loop progress update pattern from issue 101."""
+    from functools import partial  # pylint: disable=import-outside-toplevel
+
+    import streamlit as st  # pylint: disable=import-outside-toplevel
+
+    from stqdm import stqdm  # pylint: disable=import-outside-toplevel
+
+    progress = partial(stqdm, st_container=st.sidebar)
+
+    def subfun(total: int) -> None:
+        for _ in progress(range(total), desc="paragraph"):
+            pass
+
+    sections = "ABCDEFGHIJK"
+    with progress(total=len(sections), desc="Working on") as pbar:
+        for section_counter, draft_section in enumerate(sections):
+            pbar.update(section_counter)
+            pbar.set_description(desc=f"Section '{draft_section}'")
+            subfun(3)
+
+
+def issue_98_two_stqdm_instances() -> None:
+    """Reproduce the consecutive rerun pattern from issue 98."""
+    from stqdm import stqdm  # pylint: disable=import-outside-toplevel
+
+    for _ in stqdm(range(2)):
+        pass
+    for _ in stqdm(range(2)):
+        pass
+
+
 @pytest.mark.parametrize("stop_iterations,total_iterations,task_duration", [(10, 50, 5), (13, 25, 3), (0, 50, 5), (50, 50, 2)])
 def test_progress(stop_iterations: int, total_iterations: int, task_duration: float):
     with freeze_time_and_mock_long_running_task("2024-01-01"):
@@ -118,3 +150,26 @@ def test_scoped_configuration_demo_renders_description():
     progress_bars = collect_block_elements(app_test.main, should_take=lambda element: element.type == "progress")
     assert len(progress_bars) >= 2
     assert any("Hello Scoped" in getattr(progress_bar, "text", "") for progress_bar in progress_bars)
+
+
+def test_issue_101_nested_loops_do_not_raise_streamlit_api_exception():
+    with freeze_time_and_mock_long_running_task("2024-01-01"):
+        app_test = AppTest.from_function(issue_101_nested_loops_issue)
+        app_test.run(timeout=5)
+
+    assert not app_test.exception
+    progress_bars = collect_block_elements(app_test.main, should_take=lambda element: element.type == "progress")
+    progress_bars.extend(collect_block_elements(app_test.sidebar, should_take=lambda element: element.type == "progress"))
+    assert len(progress_bars) >= 2
+    assert all(0 <= progress_bar.value <= 100 for progress_bar in progress_bars)
+
+
+def test_issue_98_two_stqdm_instances_survive_reruns():
+    with freeze_time_and_mock_long_running_task("2024-01-01"):
+        app_test = AppTest.from_function(issue_98_two_stqdm_instances)
+        app_test.run(timeout=5)
+        app_test.run(timeout=5)
+
+    assert not app_test.exception
+    progress_bars = collect_block_elements(app_test.main, should_take=lambda element: element.type == "progress")
+    assert len(progress_bars) >= 1

--- a/tests/test_streamlit_frontend.py
+++ b/tests/test_streamlit_frontend.py
@@ -95,6 +95,15 @@ def test_writes_tqdm_description_when_no_length_no_total():
         )
 
 
+def test_issue_104_backend_false_does_not_emit_console_output(capsys):
+    for _ in stqdm(range(2), backend=False, frontend=True, **TQDM_RUN_EVERY_ITERATION):
+        pass
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err == ""
+
+
 @pytest.mark.parametrize(
     "bar_format,get_text",
     [


### PR DESCRIPTION
## Summary
- Fix backend-disabled progress bars so they do not leak a trailing newline on close.
- Clamp frontend progress values so nested/manual updates do not send invalid ratios to Streamlit.

## Tests
- uv run pytest tests/test_streamlit_frontend.py -k "issue_104_backend_false_does_not_emit_console_output"\n- uv run pytest tests/test_streamlit_apps.py -k "issue_101_nested_loops_do_not_raise_streamlit_api_exception or issue_98_two_stqdm_instances_survive_reruns"
- uv run pytest tests/test_streamlit_browser.py -k "nested_progress_page_renders_without_error or last_print_t_bug_page_renders_without_error"