### PR TITLE
security: harden release, reporting, and Scorecard

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -3,24 +3,26 @@ name: Create Release
 on:
   pull_request:
     # Limit to closed PR targeting main and modifying the pyproject.toml
-    types: [ closed ]
-    branches: [ main ]
-    paths: [ pyproject.toml ]
-
-permissions:
-  contents: write
+    types: [closed]
+    branches: [main]
+    paths: [pyproject.toml]
 
 jobs:
-  create-release-build-and-publish:
+  build-release-artifacts:
     # Limit to merged PR that comes from a release/v branch
-    if: (github.event.pull_request.merged == true && startsWith(github.head_ref, 'release/v'))
+    if: github.event.pull_request.merged == true && startsWith(github.head_ref, 'release/v')
     environment: publish
-    name: Create Release, Build & Publish to pypi
+    name: Build and publish GitHub release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    outputs:
+      version: ${{ steps.release-data.outputs.version }}
+      prerelease_flag: ${{ steps.check-prerelease.outputs.prerelease_flag }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          token: ${{ secrets.WIRG_PAT_FOR_RELEASE }}
+          fetch-depth: 0
 
       - uses: ./.github/workflows/actions/install_dependencies
 
@@ -30,13 +32,13 @@ jobs:
           export RELEASE="v$(python -c 'import tomllib; print(tomllib.load(open("pyproject.toml", "rb"))["project"]["version"])')"
           echo "version=${RELEASE}" >> $GITHUB_OUTPUT
 
-      - name: Build
-        run: uv build
-
       - name: Check Version
         id: check-prerelease
         run: |
           [[ "$(python -c 'import tomllib; print(tomllib.load(open("pyproject.toml", "rb"))["project"]["version"])')" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || echo prerelease_flag="--prerelease" >> $GITHUB_OUTPUT
+
+      - name: Build
+        run: uv build
 
       - name: Tag "${{ steps.release-data.outputs.version }}" & Push
         run: |
@@ -46,13 +48,37 @@ jobs:
       - name: Create Release
         run: gh release create ${{ steps.release-data.outputs.version }} --generate-notes ${{ steps.check-prerelease.outputs.prerelease_flag }}
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
 
       - name: Upload artifacts
-        run: |
-          gh release upload ${{ steps.release-data.outputs.version }} dist/*
+        run: gh release upload ${{ steps.release-data.outputs.version }} dist/*
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
+
+      - name: Upload distributions for publishing
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-dist
+          path: dist/*
+
+  publish-to-pypi:
+    needs: build-release-artifacts
+    environment: publish
+    name: Publish to PyPI
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: ./.github/workflows/actions/install_dependencies
+
+      - name: Download distributions
+        uses: actions/download-artifact@v4
+        with:
+          name: release-dist
+          path: dist
 
       - name: Publish
-        run: uv publish --token ${{ secrets.PYPI_TOKEN }}
+        run: uv publish --trusted-publishing automatic dist/*

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,33 @@
+name: Scorecard
+
+on:
+  push:
+    branches: [main]
+  schedule:
+    - cron: "0 8 * * 1"
+
+jobs:
+  analysis:
+    name: OSSF Scorecard
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Run Scorecard
+        uses: ossf/scorecard-action@v2.4.3
+        with:
+          repo_token: ${{ github.token }}
+          results_file: scorecard.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload to code scanning
+        uses: github/codeql-action/upload-sarif@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4.35.4
+        with:
+          sarif_file: scorecard.sarif

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 - Tightened the shared `.nox` cache key to avoid reusing incompatible environments.
 - Restored the session-manifest cache in CI with branch-scoped keys and a `main` fallback.
 - Removed the unused `create_auto_merge_pr` workflow helper.
+- Added private vulnerability reporting instructions in `SECURITY.md`.
+- Added scheduled OpenSSF Scorecard coverage for the repository.
+- Reworked the release workflow to use `GITHUB_TOKEN` for GitHub release actions and Trusted Publishing for PyPI uploads.
 
 ### Added
 - Issue #106: more complex examples
@@ -20,6 +23,7 @@
 - Issue #93: `bar_format` rendering
 
 ### Documentation
+- Added a short maintenance/status note to the README.
 - Expanded the Streamlit demo surface with examples for:
   - main and sidebar placement
   - multiple bars in columns

--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@ stqdm is the simplest way to handle a progress bar in streamlit app.
 
 ![demo gif](https://raw.githubusercontent.com/Wirg/stqdm/main/assets/demo.gif)
 
+## Maintenance Status
+
+STqdm is intentionally small and low-churn, but it is actively maintained for compatibility and security.
+
+The public API is kept close to `tqdm`, supported combinations are tracked in CI, and security reports should be sent privately through [SECURITY.md](SECURITY.md).
+
 ## How to install
 
 ```sh

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,19 @@
+# Security Policy
+
+## Supported Versions
+
+We actively maintain the current release line and the versions covered by the repository's compatibility matrix.
+
+Security fixes are prioritized for supported versions. Older releases may receive best-effort fixes when practical, but they should not be assumed to get backports.
+
+## Reporting a Vulnerability
+
+Please report suspected vulnerabilities privately through GitHub's "Report a vulnerability" flow in the repository's Security tab.
+
+Do not open a public issue or pull request for a security report.
+
+## Response Targets
+
+We try to acknowledge private reports within 3 business days.
+
+For confirmed issues, we aim to provide a mitigation or fix within 14 days for high-impact findings, and we will keep reporters updated if more time is needed.


### PR DESCRIPTION
Adds SECURITY.md, a short maintenance/status note in the README, scheduled OpenSSF Scorecard coverage, and a release workflow refactor that removes the PyPI token in favor of Trusted Publishing.\n\nVerification:\n- uv run nox -s release ✅\n- uv run pytest ⚠️ failed in tests/test_streamlit_browser.py::test_columns_page_renders_multiple_progress_bars (existing browser smoke mismatch)