### PR TITLE
ci: fix bump-version workflow to use uv version

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -11,10 +11,12 @@ on:
           - patch
           - minor
           - major
-          - prerelease
-          - prepatch
-          - preminor
-          - prepatch
+          - alpha
+          - beta
+          - rc
+          - dev
+          - post
+          - stable
 
 permissions:
   contents: read
@@ -30,7 +32,7 @@ jobs:
       - uses: ./.github/workflows/actions/install_dependencies
 
       - name: bump version
-        run: uv run hatch version ${{ github.event.inputs.version }}
+        run: uv version --bump ${{ github.event.inputs.version }}
 
       - name: export release-data
         id: release-data


### PR DESCRIPTION
## Summary
- replace failing uv run hatch version step with uv version --bump
- keep major/minor/patch bump semantics
- remove legacy/non-UV bump input names and duplicate prepatch option
- use UV-native bump choices: alpha, beta, rc, dev, post, stable

## Why
The previous bump step fails with static PEP 621 project.version.

## Validation
- git diff --check
- workflow YAML parse sanity (.github/workflows/bump-version.yml)