### PR TITLE
ci: use GitHub App token for release PRs

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -19,8 +19,7 @@ on:
           - stable
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   bump-version:
@@ -42,6 +41,15 @@ jobs:
           echo "version=${RELEASE}" >> $GITHUB_OUTPUT
           echo "branch=release/${RELEASE}" >> $GITHUB_OUTPUT
 
+      - name: Create release app token
+        id: release-app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
+
       - name: Create Pull Request "[Release] ${{ steps.release-data.outputs.version }} => main"
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         id: create-pull-request
@@ -61,11 +69,11 @@ jobs:
             ./uv.lock
 
           # Auth
-          token: ${{ github.token }}
+          token: ${{ steps.release-app-token.outputs.token }}
 
       - name: Auto-merge Pull Request
         uses: peter-evans/enable-pull-request-automerge@a660677d5469627102a1c1e11409dd063606628d # v3.0.0
         with:
-          token: ${{ github.token }}
+          token: ${{ steps.release-app-token.outputs.token }}
           pull-request-number: ${{ steps.create-pull-request.outputs.pull-request-number }}
           merge-method: rebase

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -19,7 +19,8 @@ on:
           - stable
 
 permissions:
-  contents: read
+  contents: write
+  pull-requests: write
 
 jobs:
   bump-version:
@@ -60,11 +61,11 @@ jobs:
             ./uv.lock
 
           # Auth
-          token: ${{ secrets.GH_WIRG_BOT_PAT }}
+          token: ${{ github.token }}
 
       - name: Auto-merge Pull Request
         uses: peter-evans/enable-pull-request-automerge@a660677d5469627102a1c1e11409dd063606628d # v3.0.0
         with:
-          token: ${{ secrets.GH_WIRG_BOT_PAT }}
+          token: ${{ github.token }}
           pull-request-number: ${{ steps.create-pull-request.outputs.pull-request-number }}
           merge-method: rebase


### PR DESCRIPTION
## Summary
- create a short-lived GitHub App installation token in the bump-version workflow
- use that token for release PR creation and auto-merge setup
- replace the stale GH_WIRG_BOT_PAT path without falling back to GITHUB_TOKEN

## Why
The release bump workflow failed when create-pull-request tried to push release/v0.1.0:

fatal: could not read Username for https://github.com

Using GITHUB_TOKEN would reduce secret management, but it changes the desired release flow because workflow-created PRs do not behave the same for CI triggering. A GitHub App token preserves the bot-authored release PR flow while using a short-lived credential.

## Required repository setup
- GitHub App installed on Wirg/stqdm
- Repository variable: RELEASE_APP_CLIENT_ID
- Repository secret: RELEASE_APP_PRIVATE_KEY
- App permissions: Contents read/write, Pull requests read/write, Metadata read

## Validation
- git diff --check
- YAML parse check for .github/workflows/bump-version.yml
- pre-commit hooks during commit