### PR TITLE
ci: fix release bump commit message

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -63,7 +63,7 @@ jobs:
           delete-branch: true
 
           # Commit
-          commit-message: "bump to version ${{ steps.release-data.outputs.version }}"
+          commit-message: "bump: version ${{ steps.release-data.outputs.version }}"
           add-paths: |
             ./pyproject.toml
             ./uv.lock


### PR DESCRIPTION
## Summary
- make automated release bump commits use the conventional commit format
- keep release PR creation behavior unchanged

## Verification
- git diff --check
- ruby -e "require 'yaml'; YAML.load_file('.github/workflows/bump-version.yml'); puts 'yaml ok'"
- uv run cz check --message "bump: version v0.1.0"