### PR TITLE
ci: run release publishing from main

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,16 +1,19 @@
 name: Create Release
 
 on:
-  pull_request:
-    # Limit to closed PR targeting main and modifying the pyproject.toml
-    types: [closed]
+  push:
     branches: [main]
     paths: [pyproject.toml]
+  workflow_dispatch:
 
 jobs:
   build-release-artifacts:
-    # Limit to merged PR that comes from a release/v branch
-    if: github.event.pull_request.merged == true && startsWith(github.head_ref, 'release/v')
+    # Publish only from main. Automatic runs are limited to release bump commits;
+    # workflow_dispatch is kept as an explicit recovery path for release automation.
+    if: >-
+      github.ref == 'refs/heads/main' &&
+      (github.event_name == 'workflow_dispatch' ||
+      startsWith(github.event.head_commit.message, 'bump: version v'))
     environment: publish
     name: Build and publish GitHub release
     runs-on: ubuntu-latest
@@ -31,6 +34,13 @@ jobs:
         run: |
           export RELEASE="v$(python -c 'import tomllib; print(tomllib.load(open("pyproject.toml", "rb"))["project"]["version"])')"
           echo "version=${RELEASE}" >> $GITHUB_OUTPUT
+
+      - name: Check release tag does not exist
+        run: |
+          if git rev-parse -q --verify "refs/tags/${{ steps.release-data.outputs.version }}" >/dev/null; then
+            echo "Release tag ${{ steps.release-data.outputs.version }} already exists."
+            exit 1
+          fi
 
       - name: Check Version
         id: check-prerelease


### PR DESCRIPTION
## Summary
- move release publishing from pull_request.closed to push-on-main so the publish environment sees the main branch ref
- keep workflow_dispatch as an explicit recovery path for the already-landed v0.1.0 bump
- add a tag-exists guard before creating a release tag

## Verification
- git diff --check
- ruby -e "require 'yaml'; YAML.load_file('.github/workflows/create-release.yml'); puts 'yaml ok'"
- uv run nox -s release

## Follow-up after merge
Run the Create Release workflow manually from main to publish the already-landed v0.1.0 version.