### PR TITLE
ci: use release app token for tag publishing

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -23,9 +23,18 @@ jobs:
       version: ${{ steps.release-data.outputs.version }}
       prerelease_flag: ${{ steps.check-prerelease.outputs.prerelease_flag }}
     steps:
+      - name: Create release app token
+        id: release-app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          permission-contents: write
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          token: ${{ steps.release-app-token.outputs.token }}
 
       - uses: ./.github/workflows/actions/install_dependencies
 
@@ -58,12 +67,12 @@ jobs:
       - name: Create Release
         run: gh release create ${{ steps.release-data.outputs.version }} --generate-notes ${{ steps.check-prerelease.outputs.prerelease_flag }}
         env:
-          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ steps.release-app-token.outputs.token }}
 
       - name: Upload artifacts
         run: gh release upload ${{ steps.release-data.outputs.version }} dist/*
         env:
-          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ steps.release-app-token.outputs.token }}
 
       - name: Upload distributions for publishing
         uses: actions/upload-artifact@v4

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -18,23 +18,14 @@ jobs:
     name: Build and publish GitHub release
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: read
     outputs:
       version: ${{ steps.release-data.outputs.version }}
       prerelease_flag: ${{ steps.check-prerelease.outputs.prerelease_flag }}
     steps:
-      - name: Create release app token
-        id: release-app-token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
-        with:
-          client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
-          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
-          permission-contents: write
-
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
-          token: ${{ steps.release-app-token.outputs.token }}
 
       - uses: ./.github/workflows/actions/install_dependencies
 
@@ -59,20 +50,28 @@ jobs:
       - name: Build
         run: uv build
 
-      - name: Tag "${{ steps.release-data.outputs.version }}" & Push
+      - name: Create release app token
+        id: release-app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          permission-contents: write
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ steps.release-app-token.outputs.token }}
         run: |
-          git tag ${{ steps.release-data.outputs.version }}
-          git push origin ${{ steps.release-data.outputs.version }}
-
-      - name: Create Release
-        run: gh release create ${{ steps.release-data.outputs.version }} --generate-notes ${{ steps.check-prerelease.outputs.prerelease_flag }}
-        env:
-          GITHUB_TOKEN: ${{ steps.release-app-token.outputs.token }}
-
-      - name: Upload artifacts
-        run: gh release upload ${{ steps.release-data.outputs.version }} dist/*
-        env:
-          GITHUB_TOKEN: ${{ steps.release-app-token.outputs.token }}
+          args=(
+            "${{ steps.release-data.outputs.version }}"
+            dist/*
+            --target "$GITHUB_SHA"
+            --generate-notes
+          )
+          if [[ -n "${{ steps.check-prerelease.outputs.prerelease_flag }}" ]]; then
+            args+=("${{ steps.check-prerelease.outputs.prerelease_flag }}")
+          fi
+          gh release create "${args[@]}"
 
       - name: Upload distributions for publishing
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
- use the release GitHub App token for release checkout, tag push, and GitHub release upload
- keep PyPI publishing on Trusted Publishing/OIDC

## Verification
- git diff --check
- YAML parse for .github/workflows/create-release.yml
- uv run nox -s release

## Follow-up before retrying v0.1.0
Add the stqdm-bot GitHub App as an Always allow bypass actor on the tag creation/update ruleset for refs/tags/v*.