### PR TITLE
ci: restore automatic release publishing

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -2,19 +2,23 @@ name: Create Release
 
 on:
   push:
-    tags:
-      - "v*"
+    branches: [main]
+    paths: [pyproject.toml]
   workflow_dispatch:
 
 jobs:
   build-release-artifacts:
-    # Releases are driven by maintainer-created v* tags. This keeps protected tag
-    # creation outside CI and lets the workflow verify the tag before publishing.
-    if: github.ref_type == 'tag' && startsWith(github.ref_name, 'v')
-    name: Build and publish GitHub release artifacts
+    # Publish only from main. Automatic runs are limited to release bump commits;
+    # workflow_dispatch is kept as an explicit recovery path for release automation.
+    if: >-
+      github.ref == 'refs/heads/main' &&
+      (github.event_name == 'workflow_dispatch' ||
+      startsWith(github.event.head_commit.message, 'bump: version v'))
+    environment: publish
+    name: Build and publish GitHub release
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: read
     outputs:
       version: ${{ steps.release-data.outputs.version }}
       prerelease_flag: ${{ steps.check-prerelease.outputs.prerelease_flag }}
@@ -28,32 +32,40 @@ jobs:
       - name: export release-data
         id: release-data
         run: |
-          PACKAGE_VERSION="$(python -c 'import tomllib; print(tomllib.load(open("pyproject.toml", "rb"))["project"]["version"])')"
-          RELEASE="v${PACKAGE_VERSION}"
-          if [[ "${GITHUB_REF_NAME}" != "${RELEASE}" ]]; then
-            echo "Tag ${GITHUB_REF_NAME} does not match pyproject.toml version ${PACKAGE_VERSION}."
+          export RELEASE="v$(python -c 'import tomllib; print(tomllib.load(open("pyproject.toml", "rb"))["project"]["version"])')"
+          echo "version=${RELEASE}" >> $GITHUB_OUTPUT
+
+      - name: Check release tag does not exist
+        run: |
+          if git rev-parse -q --verify "refs/tags/${{ steps.release-data.outputs.version }}" >/dev/null; then
+            echo "Release tag ${{ steps.release-data.outputs.version }} already exists."
             exit 1
           fi
-
-          echo "package_version=${PACKAGE_VERSION}" >> "$GITHUB_OUTPUT"
-          echo "version=${RELEASE}" >> "$GITHUB_OUTPUT"
 
       - name: Check Version
         id: check-prerelease
         run: |
-          [[ "${{ steps.release-data.outputs.package_version }}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || echo prerelease_flag="--prerelease" >> "$GITHUB_OUTPUT"
+          [[ "$(python -c 'import tomllib; print(tomllib.load(open("pyproject.toml", "rb"))["project"]["version"])')" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || echo prerelease_flag="--prerelease" >> $GITHUB_OUTPUT
 
       - name: Build
         run: uv build
 
+      - name: Create release app token
+        id: release-app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          permission-contents: write
+
       - name: Create GitHub release
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.release-app-token.outputs.token }}
         run: |
           args=(
             "${{ steps.release-data.outputs.version }}"
             dist/*
-            --verify-tag
+            --target "$GITHUB_SHA"
             --generate-notes
           )
           if [[ -n "${{ steps.check-prerelease.outputs.prerelease_flag }}" ]]; then


### PR DESCRIPTION
## Summary
- restore release publishing from version-bump pushes to main
- restore GitHub App token use for creating the GitHub Release and its v* tag
- keep build/publish split and PyPI Trusted Publishing/OIDC

## Required repository setting
The v* tag creation ruleset must allow the stqdm-bot GitHub App to bypass tag creation/update, otherwise GitHub will keep rejecting automatic tag creation with: Cannot create ref due to creations being restricted.

## Validation
- git diff --check
- YAML parse for .github/workflows/create-release.yml
- uv run nox -s release