### PR TITLE
Fix lazy containers and bar format parsing

### DIFF
--- a/stqdm/stqdm.py
+++ b/stqdm/stqdm.py
@@ -45,7 +45,7 @@ class stqdm(tqdm):  # pylint: disable=invalid-name,inconsistent-mro
         """
         merged_kwargs = self.combine_default_and_provided_kwargs(provided_config=kwargs)
 
-        self.st_container: "DeltaGenerator" = merged_kwargs.pop("st_container", st.container())
+        self._st_container: Optional["DeltaGenerator"] = merged_kwargs.pop("st_container", None)
         self._backend: bool = merged_kwargs.pop("backend", False)
         self._frontend: bool = merged_kwargs.pop("frontend", True)
         if not self._backend:
@@ -129,6 +129,17 @@ class stqdm(tqdm):  # pylint: disable=invalid-name,inconsistent-mro
     ###
     # Internal Functions
     ###
+
+    @property
+    def st_container(self) -> "DeltaGenerator":
+        """Lazily creates and returns the Streamlit container used by frontend rendering."""
+        if self._st_container is None:
+            self._st_container = st.container()
+        return self._st_container
+
+    @st_container.setter
+    def st_container(self, value: "DeltaGenerator") -> None:
+        self._st_container = value
 
     @property
     def st_progress_bar(self) -> "DeltaGenerator":

--- a/stqdm/stqdm.py
+++ b/stqdm/stqdm.py
@@ -1,7 +1,7 @@
 import io
-import re
 from collections.abc import AsyncIterator, Iterable
 from contextlib import contextmanager
+from string import Formatter
 from typing import TYPE_CHECKING, Any, Generator, Optional, cast
 
 import streamlit as st
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
     from streamlit.delta_generator import DeltaGenerator
 
 IS_TEXT_INSIDE_PROGRESS_AVAILABLE = version.parse(st.__version__) >= version.parse("1.18.0")
-BAR_FORMAT_REGEX = re.compile(r"\{bar(?:[:!][a-zA-Z0-9]+){,2}}")
+FORMATTER = Formatter()
 
 
 class stqdm(tqdm):  # pylint: disable=invalid-name,inconsistent-mro
@@ -262,10 +262,8 @@ class stqdm(tqdm):  # pylint: disable=invalid-name,inconsistent-mro
             should_display_progress_bar = True
             should_display_text = False
         else:
-            original_bar_format = bar_format
             # {bar:size} defines the bar + its size (default 10)
-            bar_format = re.sub(BAR_FORMAT_REGEX, "", bar_format)
-            should_display_progress_bar = bar_format != original_bar_format
+            bar_format, should_display_progress_bar = stqdm._remove_bar_from_format(bar_format)
             should_display_text = bool(bar_format.strip())
         return {
             # ncols should not impact text of stqdm's frontend
@@ -279,4 +277,34 @@ class stqdm(tqdm):  # pylint: disable=invalid-name,inconsistent-mro
     @staticmethod
     def remove_bar_from_format(bar_format: str) -> str:
         """Remove tqdm's terminal bar placeholder from text shown in Streamlit."""
-        return re.sub(BAR_FORMAT_REGEX, "", bar_format)
+        barless_format, _ = stqdm._remove_bar_from_format(bar_format)
+        return barless_format
+
+    @staticmethod
+    def _remove_bar_from_format(bar_format: str) -> tuple[str, bool]:
+        """Return text without tqdm's bar placeholder and whether one was present."""
+        has_bar = False
+        barless_format = []
+        for literal_text, field_name, format_spec, conversion in FORMATTER.parse(bar_format):
+            # Formatter normalizes some fields, so detect the bar placeholder separately.
+            is_bar_placeholder = field_name == "bar" and conversion is None
+            has_bar = has_bar or is_bar_placeholder
+            barless_format.append(stqdm._format_barless_part(literal_text, field_name, format_spec, conversion))
+        return "".join(barless_format), has_bar
+
+    @staticmethod
+    def _format_barless_part(
+        literal_text: str,
+        field_name: str | None,
+        format_spec: str | None,
+        conversion: str | None,
+    ) -> str:
+        literal_text = literal_text.replace("{", "{{").replace("}", "}}")
+        if field_name is None:
+            return literal_text
+        if field_name == "bar" and conversion is None:
+            return literal_text
+
+        conversion_text = f"!{conversion}" if conversion is not None else ""
+        format_spec_text = f":{format_spec}" if format_spec else ""
+        return f"{literal_text}{{{field_name}{conversion_text}{format_spec_text}}}"

--- a/tests/test_streamlit_apps.py
+++ b/tests/test_streamlit_apps.py
@@ -28,6 +28,17 @@ def collect_block_elements(block: Block, should_take: Callable[[Element], bool])
     return results
 
 
+def collect_blocks(block: Block, should_take: Callable[[Block], bool]) -> list[Block]:
+    children = block.children.values()
+    results: list[Block] = []
+    for child in children:
+        if isinstance(child, Block):
+            if should_take(child):
+                results.append(child)
+            results.extend(collect_blocks(child, should_take))
+    return results
+
+
 @contextlib.contextmanager
 def freeze_time_and_mock_long_running_task(original_date: str):
     """A context manager that uses freezegun to freeze time and mock the long_running_task function."""
@@ -67,6 +78,50 @@ for _ in stqdm(range(2)):
 
 for _ in stqdm(range(2)):
     pass
+"""
+
+
+SIDEBAR_CONTAINER_SCRIPT = """
+import streamlit as st
+from stqdm import stqdm
+
+st.write("main-before")
+for _ in stqdm(range(2), st_container=st.sidebar):
+    pass
+st.write("main-after")
+"""
+
+
+FRONTEND_DISABLED_SCRIPT = """
+import streamlit as st
+from stqdm import stqdm
+
+st.write("main-before")
+for _ in stqdm(range(2), frontend=False):
+    pass
+st.write("main-after")
+"""
+
+
+DISABLED_SCRIPT = """
+import streamlit as st
+from stqdm import stqdm
+
+st.write("main-before")
+for _ in stqdm(range(2), disable=True):
+    pass
+st.write("main-after")
+"""
+
+
+DELAYED_SCRIPT = """
+import streamlit as st
+from stqdm import stqdm
+
+st.write("main-before")
+for _ in stqdm(range(2), delay=999):
+    pass
+st.write("main-after")
 """
 
 
@@ -193,6 +248,40 @@ def test_issue_98_two_stqdm_instances_survive_reruns():
     assert not app_test.exception
     progress_bars = collect_block_elements(app_test.main, should_take=lambda element: element.type == "progress")
     assert len(progress_bars) >= 1
+
+
+def test_sidebar_container_does_not_create_unused_main_container():
+    app_test = AppTest.from_string(SIDEBAR_CONTAINER_SCRIPT)
+    app_test.run(timeout=5)
+
+    assert not app_test.exception
+    main_containers = collect_blocks(app_test.main, should_take=lambda block: block.type == "flex_container")
+    sidebar_progress_bars = collect_block_elements(app_test.sidebar, should_take=lambda element: element.type == "progress")
+    assert not main_containers
+    assert len(sidebar_progress_bars) == 1
+
+
+def test_frontend_disabled_does_not_create_unused_main_container():
+    app_test = AppTest.from_string(FRONTEND_DISABLED_SCRIPT)
+    app_test.run(timeout=5)
+
+    assert not app_test.exception
+    main_containers = collect_blocks(app_test.main, should_take=lambda block: block.type == "flex_container")
+    progress_bars = collect_block_elements(app_test.main, should_take=lambda element: element.type == "progress")
+    assert not main_containers
+    assert not progress_bars
+
+
+@pytest.mark.parametrize("script", [DISABLED_SCRIPT, DELAYED_SCRIPT])
+def test_no_frontend_display_does_not_create_unused_main_container(script: str):
+    app_test = AppTest.from_string(script)
+    app_test.run(timeout=5)
+
+    assert not app_test.exception
+    main_containers = collect_blocks(app_test.main, should_take=lambda block: block.type == "flex_container")
+    progress_bars = collect_block_elements(app_test.main, should_take=lambda element: element.type == "progress")
+    assert not main_containers
+    assert not progress_bars
 
 
 def test_asyncio_demo_renders_and_completes():

--- a/tests/test_streamlit_frontend.py
+++ b/tests/test_streamlit_frontend.py
@@ -139,6 +139,10 @@ def test_issue_104_backend_false_does_not_emit_console_output(capsys):
             "{l_bar}{bar}{r_bar}",
             lambda i, total: tqdm.format_meter(n=i, total=total, elapsed=i, bar_format="{l_bar}{r_bar}", prefix=DESCRIPTION),
         ),
+        (
+            "{l_bar}{bar:-10b}{r_bar}",
+            lambda i, total: tqdm.format_meter(n=i, total=total, elapsed=i, bar_format="{l_bar}{r_bar}", prefix=DESCRIPTION),
+        ),
     ],
 )
 def test_bar_format(bar_format, get_text):
@@ -151,6 +155,58 @@ def test_bar_format(bar_format, get_text):
                 text=get_text(i=i, total=2),
                 progress=i / len(stqdmed_iterator),
             )
+
+
+def test_escaped_bar_placeholder_is_treated_as_text_not_progress_bar():
+    stqdmed_iterator = stqdm(range(2), bar_format="{{bar}}", desc=DESCRIPTION, **TQDM_RUN_EVERY_ITERATION)
+
+    for _ in stqdmed_iterator:
+        assert_frontend_as_been_called_with(
+            stqdmed_iterator,
+            text="{bar}",
+            progress=None,
+        )
+
+
+@pytest.mark.parametrize(
+    "bar_format,expected_barless_format",
+    [
+        ("{bar:10}", ""),
+        ("{bar:-10b}", ""),
+        ("{bar:a}", ""),
+        ("{bar:u}", ""),
+        ("{bar:{width}}", ""),
+        ("{bar:>{width}}", ""),
+        ("{bar:}", ""),
+        ("{l_bar}{bar}{r_bar}", "{l_bar}{r_bar}"),
+        ("{desc:}", "{desc}"),
+        ("{desc!s:}", "{desc!s}"),
+        ("{n:}", "{n}"),
+        ("{n!s:}", "{n!s}"),
+        ("{desc} {percentage:.0f}%", "{desc} {percentage:.0f}%"),
+        ("{{bar}}", "{{bar}}"),
+        ("{n:{width}}", "{n:{width}}"),
+        ("{{x}}{bar}{unknown:{width}}", "{{x}}{unknown:{width}}"),
+    ],
+)
+def test_remove_bar_from_format_preserves_non_bar_format_fields(bar_format, expected_barless_format):
+    assert stqdm.remove_bar_from_format(bar_format) == expected_barless_format
+
+
+@pytest.mark.parametrize("bar_format", ["{bar!s}", "{bar!r}", "{bar!a}", "{bar!s:}"])
+def test_bar_placeholder_with_conversion_is_not_treated_as_progress_bar(bar_format):
+    frontend_config = stqdm.build_frontend_config_overrides(bar_format=bar_format)
+
+    assert frontend_config["should_display_progress_bar"] is False
+    assert frontend_config["should_display_text"] is True
+
+
+@pytest.mark.parametrize("bar_format", ["{desc:}", "{desc!s:}", "{n:}", "{n!s:}"])
+def test_reconstructed_format_without_bar_does_not_display_progress_bar(bar_format):
+    frontend_config = stqdm.build_frontend_config_overrides(bar_format=bar_format)
+
+    assert frontend_config["should_display_progress_bar"] is False
+    assert frontend_config["should_display_text"] is True
 
 
 def test_backend_format_is_not_rewritten_by_frontend_compatibility():


### PR DESCRIPTION
## Summary
- lazily create the default Streamlit container so sidebar, disabled, and delayed progress bars do not leave unused main containers
- parse tqdm bar format strings with Python's formatter parser so escaped braces are preserved and real {bar} placeholders are removed precisely

## Verification
- uv run pytest
- uv run pyrefly check stqdm